### PR TITLE
Feat/i cougar manager.override start

### DIFF
--- a/CustomCougarManager.cs
+++ b/CustomCougarManager.cs
@@ -45,7 +45,7 @@ namespace ImprovedCougar
 
         // Because you are running as a mono and not running on EAF's loop, these are important to prevent running during main menu and such
         public bool IsMenuScene = true; // initialize TRUE to prevent updates at start during main menu
-        public bool HasStarted = true; // initialize TRUE to prevent start running in main menu
+        public bool HasStarted = false; // can be initialized at false now that I have this starting on OverrideStart() which correctly starts up only when a save is loaded
         
         // ModData 
         private ModDataManager modData = new ModDataManager("ImprovedCougar", false);

--- a/CustomCougarManager.cs
+++ b/CustomCougarManager.cs
@@ -100,19 +100,37 @@ namespace ImprovedCougar
         }
 
 
-        public void Start()
+        // once past "HasStarted = true", the only thing here that probably matters to you is "mVanillaManager.IsEnabled = true" which is what vailla does on Start()
+        // I am overriding CougarManager.Start now, and I'm handling that within EAF's native cougarmanager so at minimum you need to enable the vanilla manager here
+        // (this is all assuming you continue to rely on that flag - the most important part is "Il2CppTLD.AI.CougarManager.s_EnableInNewGame" flag!)
+        public void OverrideStart()
         {
-            if (HasStarted)
+            if (HasStarted) return;
+            if (ShouldAbortStart()) 
             {
+                if (mVanillaManager != null)
+                {
+                    mVanillaManager.IsEnabled = false;
+                }
                 return;
             }
             HasStarted = true;
+            VanillaCougarManager.s_CougarSettingsOverride = false;
+            VanillaCougarManager.m_CurrentThreatLevelByRegion.Clear();
+            mVanillaManager.m_CurrentThreatCooldownByRegion.Clear();
+            mVanillaManager.IsEnabled = true;
+            mVanillaManager.m_Cougar_TerritoryZone_EnterID = 0;
+            mVanillaManager.m_Cougar_TerritoryZone_ExitID = 0;
+            mVanillaManager.m_Cougar_NearbyOutsideID = 0;
+            VanillaCougarManager.SetAudioState(mVanillaManager.m_CougarTerritory_ZoneThreatLevel_ctztl_0);
+        }
 
-            //i think this checks if the feature is enabled
-            if (!VanillaCougarManager.IsEnabled) return;
-
-            // You can do other stuff here if you want, I configured this to run every scene start based on EAF's timing of InitializeScene
-            // But honestly now that it's persistent across saves and uses ModData properly, you can probably just drop Start()...
+        private bool ShouldAbortStart()
+        {            
+            if (!VanillaCougarManager.GetCougarSettings(true)) return true;
+            if (!VanillaCougarManager.s_EnableInNewGame) return true;
+            if (VanillaCougarManager == null) return true;
+            return false;
         }
 
         public void Update()
@@ -361,6 +379,7 @@ namespace ImprovedCougar
             if (SceneUtilities.IsSceneMenu(sceneName))
             {
                 IsMenuScene = true;
+                HasStarted = false;
                 return;
             }
             if (SceneUtilities.IsScenePlayable(sceneName) 

--- a/SpawnRegions/CustomCougarSpawnRegion.cs
+++ b/SpawnRegions/CustomCougarSpawnRegion.cs
@@ -16,6 +16,11 @@ namespace ImprovedCougar.SpawnRegions
 
         protected override bool OverrideCalculateTargetPopulation(out int customTarget)
         {
+            if (VanillaSpawnRegion.m_WildlifeMode == WildlifeMode.Aurora)
+            {
+                customTarget = 0;
+                return false;
+            }
             // if cougar alive, return 1
             // if cougar dead or not ready to appear, return 0
             customTarget = 1 - mSpawnRegion.m_NumRespawnsPending; // this will work per region, but wont take into account a cougar that lives in multiple game zones or something


### PR DESCRIPTION
1) Ensure no aurora spawns under normal conditions
2) Introduce ICougarManager.OverrideStart which occurs on any kind of new/existing save initialize
3) (not here, but in EAF) Ensure force spawning checks proxy vs region aurora condition

The overridestart code is very similar to EAFs CougarManager, but the only important part is this:

if (!VanillaCougarManager.GetCougarSettings(true)) -> no cougar
if (!VanillaCougarManager.s_EnableInNewGame) -> no cougar

do with that what you will!

<img width="3768" height="2109" alt="image" src="https://github.com/user-attachments/assets/e12ef2b4-d692-4ba4-a941-500c95536df2" />
