### PR TITLE
feat: implement CustomBaseAi.IncrementKillStat()

### DIFF
--- a/CustomCougar.cs
+++ b/CustomCougar.cs
@@ -1004,6 +1004,12 @@ namespace ImprovedCougar
             return false;
         }
 
+        #region EAF Abstract Implementations
+
+        protected override void IncrementKillStat() => StatsManager.IncrementValue(Il2CppTLD.Stats.StatID.CougarsKilled);
+
+        #endregion
+
         //debug
         private void DoOnUpdate()
         {

--- a/CustomCougarManager.cs
+++ b/CustomCougarManager.cs
@@ -12,7 +12,7 @@ using System.Threading.Tasks;
 using UnityEngine;
 using UnityEngine.SceneManagement;
 using ModData;
-using MelonLoader.TinyJSON; 
+using Newtonsoft.Json;
 using Random = UnityEngine.Random;
 
 namespace ImprovedCougar
@@ -490,7 +490,7 @@ namespace ImprovedCougar
             loadData.lastSpawnRegionSP = lastSpawnRegionSP;
             loadData.latestRegion = latestRegion;
 
-            string json = JSON.Dump(loadData, EncodeOptions.PrettyPrint | EncodeOptions.NoTypeHints);
+            string json = JsonConvert.SerializeObject(loadData);
             if (json == null || json == string.Empty)
             {
                 return;
@@ -505,9 +505,7 @@ namespace ImprovedCougar
             {
                 return;
             }
-            Variant loadDataVariant = JSON.Load(loadDataJSON);
-            LoadData loadData = new LoadData();
-            JSON.Populate(loadDataVariant, loadData);
+            LoadData loadData = JsonConvert.DeserializeObject<LoadData>(loadDataJSON) ?? new LoadData();
             if(!loadData.CougarArrived && loadData.DaysToArrive == 0)
             {
 

--- a/ImprovedCougar.csproj
+++ b/ImprovedCougar.csproj
@@ -46,6 +46,10 @@
 		</Reference>
 	</ItemGroup>
 
+  <ItemGroup>
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
+  </ItemGroup>
+
 	<ItemGroup>
 		<Using Include="System.Reflection" />
 		<Using Include="System.Diagnostics.CodeAnalysis" />


### PR DESCRIPTION
MUCH better. I didnt realize you kept 2.0 on its own dedicated branch, good thinking but tripped me up the first time.

# WHY

As you know, EAF lobotomizes large parts of the AI system. Kill stat incrementing is supposed to be handled in BaseAi.EnterDead but for whatever reason it is not firing anymore.

As part of a pivot towards implementing features more sensibly vs. just copying HL's approach, you will start seeing these kinds of PRs often as I carry logic out of the BaseAI class and into dedicated variants, there's a lot of places this happens where the game checks "what kind of AI is this" before doing something when we can just... use...OOP.... 

Let me know when you are at a good point to release this, we need to release simultaneously as this is the equivalent of an API update.